### PR TITLE
Fix build error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.9.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/styles": "^4.11.5",
     "bootstrap": "^4.4.1",
     "d3": "^5.9.2",
     "dagre": "^0.8.4",


### PR DESCRIPTION
After running the `npm start` command, an error occurred.
To fix this error, add a missing package `@material-ui/styles`

```sh
./src/components/CaptureTab.js
Module not found: Can't resolve '@material-ui/styles' in 'C:\Users\taesh\Desktop
\githru\frontend\src\components'
```


#### Environment
- Windows 10
- node 16
- git bash